### PR TITLE
increase mdlscale x1.5 for bandit/priv

### DIFF
--- a/bandit/priv/bandit_config.cfg
+++ b/bandit/priv/bandit_config.cfg
@@ -21,7 +21,7 @@ if  (> $bandit_type 2) [
 ]
 
 if (|| (= $bandit_type 1) (= $bandit_type 3)) [
-    mdlscale 1234
+    mdlscale 1851
     mdlyaw 180
     mdlpitch 0
     mdlroll -8
@@ -29,7 +29,7 @@ if (|| (= $bandit_type 1) (= $bandit_type 3)) [
 ]
 
 if (|| (= $bandit_type 2) (= $bandit_type 4)) [
-    mdlscale 1110
+    mdlscale 1665
     mdlyaw 180
     mdlpitch 0
     mdlroll -8


### PR DESCRIPTION
bandit/priv model is inside the players neck, increasing mdlscale by x1.5 fixes that.